### PR TITLE
Correct noscript fallback for Empty Edition

### DIFF
--- a/editions/tw5.com/tiddlers/system/static.content.tid
+++ b/editions/tw5.com/tiddlers/system/static.content.tid
@@ -2,13 +2,17 @@ title: $:/core/templates/static.content
 
 \define tv-wikilink-template() https://tiddlywiki.com/static/$uri_doubleencoded$.html
 
+<% if [<savingEmpty>match[yes]] %>
+
+<$transclude tiddler="$:/core" subtiddler="$:/core/templates/static.content"/>
+
+<% else %>
+
 <!-- Mastodon verification -->
 
-<a rel="me" href="https://fosstodon.org/@TiddlyWiki">Mastodon</a>
+<a rel="me" href="https://fosstodon.org/@TiddlyWiki">~TiddlyWiki on Mastodon</a>
 
 <!-- For Google, and people without JavaScript-->
-
-<$reveal default="yes" text=<<savingEmpty>> type="nomatch">
 
 It looks like this browser doesn't run JavaScript. You can use one of these static HTML versions to browse the same content:
 
@@ -19,4 +23,4 @@ It looks like this browser doesn't run JavaScript. You can use one of these stat
 
 {{TiddlyWiki}}
 
-</$reveal>
+<% endif %>


### PR DESCRIPTION
Also slightly improve the Mastodon link text (since it'll be read by people without JS)

Before this patch, if the "built-in" Empty Edition was downloaded then the Mastodon verification link was included, which is wrong. Not a super big deal since it'll get "flushed out" the first time the user saves, but still confusing.

The mastodon link could've just been moved inside the <$reveal> but I think it's better to try to achieve parity with tiddlywiki.com/empty.html;  This commit does not achieve parity but it gets us closer.